### PR TITLE
fix: fix build error

### DIFF
--- a/webview/src/components/settings/SettingsView.tsx
+++ b/webview/src/components/settings/SettingsView.tsx
@@ -11,7 +11,7 @@ import { useConfig } from "../../context/ConfigContext"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration, validateModelId } from "../../utils/validators"
 import { vscode } from "../../utils/vscode"
-import APIOptions from "./APIOptions"
+import APIOptions from "./ApiOptions"
 
 const IS_DEV = true // FIXME: use flags when packaging
 

--- a/webview/src/components/welcome/WelcomeView.tsx
+++ b/webview/src/components/welcome/WelcomeView.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react"
 import { useExtensionState } from "../../context/ExtensionStateContext"
 import { validateApiConfiguration } from "../../utils/validators"
 import { vscode } from "../../utils/vscode"
-import APIOptions from "../settings/APIOptions"
+import APIOptions from "../settings/ApiOptions"
 
 const WelcomeView = () => {
   const { apiConfiguration } = useExtensionState()


### PR DESCRIPTION
```
TS1149: File name '/Users/astandrik/workspace/codey/webview/src/components/settings/APIOptions.tsx' differs from already included file name '/Users/astandrik/workspace/codey/webview/src/components/settings/ApiOptions.tsx' only in casing.
  The file is in the program because:
    Imported via "./ApiOptions" from file '/Users/astandrik/workspace/codey/webview/src/components/settings/SettingsView.tsx'
    Root file specified for compilation
    Imported via "../settings/APIOptions" from file '/Users/astandrik/workspace/codey/webview/src/components/welcome/WelcomeView.tsx'
    4 | import { validateApiConfiguration } from "../../utils/validators"
    5 | import { vscode } from "../../utils/vscode"
  > 6 | import APIOptions from "../settings/APIOptions"
      |                        ^^^^^^^^^^^^^^^^^^^^^^^^
    7 |
    8 | const WelcomeView = () => {
    9 |   const { apiConfiguration } = useExtensionState()
```